### PR TITLE
Added "allow" attribute for links to restrict access

### DIFF
--- a/_format/1.1/normative-statements.json
+++ b/_format/1.1/normative-statements.json
@@ -857,7 +857,7 @@ layout: null
       "type": "normative-statements",
       "attributes": {
         "level": "MUST",
-        "description": "Each member of a links object is a \"link\". A link **MUST** be represented as either:\\n\\n- a string containing the link's URL.\\n- an object (\"link object\") which can contain the following members:\\n  - `href`: a string containing the link's URL.\\n  - `meta`: a meta object containing non-standard meta-information about the link."
+        "description": "Each member of a links object is a \"link\". A link **MUST** be represented as either:\\n\\n- a string containing the link's URL.\\n- an object (\"link object\") which can contain the following members:\\n  - `href`: a string containing the link's URL.\\n  - `allow`: a list of allowed HTTP methods like `[\"GET\", \"PATCH\", \"DELETE\"]` if access to the resource is restricted.  - `meta`: a meta object containing non-standard meta-information about the link."
       },
       "relationships": {
         "section": {


### PR DESCRIPTION
This PR relates to the discussion in https://github.com/json-api/json-api/issues/745

If access to a resource is limited by a permission system, the HTTP header that can be sent along with the resource is "Allow: GET, PATCH, DELETE". For included resources, the link attribute should be able to list the allowed methods the same way:
```
"links": {
  "related": {
    "href": "http://example.com/articles/1/comments",
    "allow": ["GET", "PATCH", "DELETE"]
  }
}
```
to be as close as possible to the HTTP header. Only "Allow" is in lower-case to be in line with all other keys in the JSON payload.